### PR TITLE
Reading settings from Azure Key Vault.

### DIFF
--- a/src/Equinor.Procosys.Library.WebApi/Equinor.Procosys.Library.WebApi.csproj
+++ b/src/Equinor.Procosys.Library.WebApi/Equinor.Procosys.Library.WebApi.csproj
@@ -20,6 +20,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.Configuration.AzureKeyVault" Version="3.1.3" />
     <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="5.2.7" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.9.10" />
     <PackageReference Include="ServiceResult" Version="1.0.1" />

--- a/src/Equinor.Procosys.Library.WebApi/Misc/KeyVaultSettings.cs
+++ b/src/Equinor.Procosys.Library.WebApi/Misc/KeyVaultSettings.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace Equinor.Procosys.Library.WebApi.Misc
+{
+    public class KeyVaultSettings
+    {
+        public bool Enabled { get; set; } = true;
+        public string ClientId { get; set; }
+        public string ClientSecret { get; set; }
+        public string Uri { get; set; }
+    }
+}

--- a/src/Equinor.Procosys.Library.WebApi/Program.cs
+++ b/src/Equinor.Procosys.Library.WebApi/Program.cs
@@ -1,5 +1,7 @@
 ﻿using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Configuration;
+using Equinor.Procosys.Library.WebApi.Misc;
 
 namespace Equinor.Procosys.Library.WebApi
 {
@@ -13,6 +15,15 @@ namespace Equinor.Procosys.Library.WebApi
 
         public static IHostBuilder CreateHostBuilder(string[] args) =>
             Host.CreateDefaultBuilder(args)
+                .ConfigureAppConfiguration((context, config) =>
+                {
+                    var kvSettings = new KeyVaultSettings();
+                    config.Build().GetSection("KeyVault").Bind(kvSettings);
+                    if (kvSettings.Enabled)
+                    {
+                        config.AddAzureKeyVault(kvSettings.Uri, kvSettings.ClientId, kvSettings.ClientSecret);
+                    }
+                })
                 .ConfigureWebHostDefaults(webBuilder =>
                 {
                     webBuilder.UseKestrel(options => options.AddServerHeader = false);

--- a/src/Equinor.Procosys.Library.WebApi/appsettings.Development.json
+++ b/src/Equinor.Procosys.Library.WebApi/appsettings.Development.json
@@ -6,5 +6,8 @@
       "Microsoft": "Information"
     }
   },
-  "MigrateDatabase": true
+  "MigrateDatabase": true,
+  "KeyVault": {
+    "Enabled": false
+  }
 }

--- a/src/Equinor.Procosys.Library.WebApi/appsettings.json
+++ b/src/Equinor.Procosys.Library.WebApi/appsettings.json
@@ -27,5 +27,11 @@
     "Audience": "",
     "BaseAddress": "",
     "ApiVersion": ""
+  },
+  "KeyVault": {
+    "ClientId": "",
+    "ClientSecret": "",
+    "Uri": "",
+    "Enabled": true
   }
 }


### PR DESCRIPTION
Reading settings from Azure Key Vault. Added functionality to enable/disable this to be able to use local secrets file because the Key Vault will be read last and will therefore have precedence over all other settings.