### PR TITLE
Automatic update of 12 packages

### DIFF
--- a/src/Equinor.Procosys.Library.Infrastructure/Equinor.Procosys.Library.Infrastructure.csproj
+++ b/src/Equinor.Procosys.Library.Infrastructure/Equinor.Procosys.Library.Infrastructure.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.3" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.3" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="3.1.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Equinor.Procosys.Library.Infrastructure/Equinor.Procosys.Library.Infrastructure.csproj
+++ b/src/Equinor.Procosys.Library.Infrastructure/Equinor.Procosys.Library.Infrastructure.csproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.3" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.3" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="3.1.2">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="3.1.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Equinor.Procosys.Library.Infrastructure/Equinor.Procosys.Library.Infrastructure.csproj
+++ b/src/Equinor.Procosys.Library.Infrastructure/Equinor.Procosys.Library.Infrastructure.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.3" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.2" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="3.1.2">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Equinor.Procosys.Library.Infrastructure/Equinor.Procosys.Library.Infrastructure.csproj
+++ b/src/Equinor.Procosys.Library.Infrastructure/Equinor.Procosys.Library.Infrastructure.csproj
@@ -11,7 +11,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="3.1.2" />
+    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="3.1.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Equinor.Procosys.Library.Query/Equinor.Procosys.Library.Query.csproj
+++ b/src/Equinor.Procosys.Library.Query/Equinor.Procosys.Library.Query.csproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="FluentValidation.AspNetCore" Version="8.6.2" />
     <PackageReference Include="MediatR" Version="8.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.2" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.3" />
     <PackageReference Include="ServiceResult" Version="1.0.1" />
   </ItemGroup>
 

--- a/src/Equinor.Procosys.Library.WebApi/Equinor.Procosys.Library.WebApi.csproj
+++ b/src/Equinor.Procosys.Library.WebApi/Equinor.Procosys.Library.WebApi.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="Microsoft.ApplicationInsights.PerfCounterCollector" Version="2.13.1" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.1.3" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="3.1.3" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="3.1.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="3.1.3" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="3.1.3">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Equinor.Procosys.Library.WebApi/Equinor.Procosys.Library.WebApi.csproj
+++ b/src/Equinor.Procosys.Library.WebApi/Equinor.Procosys.Library.WebApi.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="3.1.2" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="3.1.2" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="2.2.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="3.1.2">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="3.1.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Equinor.Procosys.Library.WebApi/Equinor.Procosys.Library.WebApi.csproj
+++ b/src/Equinor.Procosys.Library.WebApi/Equinor.Procosys.Library.WebApi.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="MicroElements.Swashbuckle.FluentValidation" Version="3.1.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.13.1" />
     <PackageReference Include="Microsoft.ApplicationInsights.PerfCounterCollector" Version="2.13.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.1.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.1.3" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="3.1.2" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="3.1.2" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="2.2.0" />

--- a/src/Equinor.Procosys.Library.WebApi/Equinor.Procosys.Library.WebApi.csproj
+++ b/src/Equinor.Procosys.Library.WebApi/Equinor.Procosys.Library.WebApi.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.13.1" />
     <PackageReference Include="Microsoft.ApplicationInsights.PerfCounterCollector" Version="2.13.1" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.1.3" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="3.1.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="3.1.3" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="3.1.2" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="3.1.3">

--- a/src/Tests/Equinor.Procosys.Library.Command.Tests/Equinor.Procosys.Library.Command.Tests.csproj
+++ b/src/Tests/Equinor.Procosys.Library.Command.Tests/Equinor.Procosys.Library.Command.Tests.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="FluentValidation.AspNetCore" Version="8.6.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="Moq" Version="4.13.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.1.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.1.1" />
     <PackageReference Include="MSTest.TestFramework" Version="2.1.0" />
     <PackageReference Include="coverlet.collector" Version="1.2.1">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Tests/Equinor.Procosys.Library.Command.Tests/Equinor.Procosys.Library.Command.Tests.csproj
+++ b/src/Tests/Equinor.Procosys.Library.Command.Tests/Equinor.Procosys.Library.Command.Tests.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.1.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.1.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.1.1" />
     <PackageReference Include="coverlet.collector" Version="1.2.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Tests/Equinor.Procosys.Library.Domain.Tests/Equinor.Procosys.Library.Domain.Tests.csproj
+++ b/src/Tests/Equinor.Procosys.Library.Domain.Tests/Equinor.Procosys.Library.Domain.Tests.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.1.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.1.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.1.1" />
     <PackageReference Include="coverlet.collector" Version="1.2.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Tests/Equinor.Procosys.Library.Domain.Tests/Equinor.Procosys.Library.Domain.Tests.csproj
+++ b/src/Tests/Equinor.Procosys.Library.Domain.Tests/Equinor.Procosys.Library.Domain.Tests.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="Moq" Version="4.13.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.1.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.1.1" />
     <PackageReference Include="MSTest.TestFramework" Version="2.1.0" />
     <PackageReference Include="coverlet.collector" Version="1.2.1">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Tests/Equinor.Procosys.Library.Infrastructure.Tests/Equinor.Procosys.Library.Infrastructure.Tests.csproj
+++ b/src/Tests/Equinor.Procosys.Library.Infrastructure.Tests/Equinor.Procosys.Library.Infrastructure.Tests.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="MockQueryable.Moq" Version="3.1.1" />
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.1.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.1.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.1.1" />
     <PackageReference Include="coverlet.collector" Version="1.2.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Tests/Equinor.Procosys.Library.Infrastructure.Tests/Equinor.Procosys.Library.Infrastructure.Tests.csproj
+++ b/src/Tests/Equinor.Procosys.Library.Infrastructure.Tests/Equinor.Procosys.Library.Infrastructure.Tests.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="MockQueryable.Moq" Version="3.1.1" />
     <PackageReference Include="Moq" Version="4.13.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.1.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.1.1" />
     <PackageReference Include="MSTest.TestFramework" Version="2.1.0" />
     <PackageReference Include="coverlet.collector" Version="1.2.1">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Tests/Equinor.Procosys.Library.Query.Tests/Equinor.Procosys.Library.Query.Tests.csproj
+++ b/src/Tests/Equinor.Procosys.Library.Query.Tests/Equinor.Procosys.Library.Query.Tests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.1.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.1.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.1.1" />

--- a/src/Tests/Equinor.Procosys.Library.Query.Tests/Equinor.Procosys.Library.Query.Tests.csproj
+++ b/src/Tests/Equinor.Procosys.Library.Query.Tests/Equinor.Procosys.Library.Query.Tests.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.1.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.1.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.1.1" />
     <PackageReference Include="coverlet.collector" Version="1.2.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Tests/Equinor.Procosys.Library.Query.Tests/Equinor.Procosys.Library.Query.Tests.csproj
+++ b/src/Tests/Equinor.Procosys.Library.Query.Tests/Equinor.Procosys.Library.Query.Tests.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.1.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="Moq" Version="4.13.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.1.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.1.1" />
     <PackageReference Include="MSTest.TestFramework" Version="2.1.0" />
     <PackageReference Include="coverlet.collector" Version="1.2.1">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Tests/Equinor.Procosys.Library.WebApi.Tests/Equinor.Procosys.Library.WebApi.Tests.csproj
+++ b/src/Tests/Equinor.Procosys.Library.WebApi.Tests/Equinor.Procosys.Library.WebApi.Tests.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.1.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.1.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.1.1" />
     <PackageReference Include="coverlet.collector" Version="1.2.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Tests/Equinor.Procosys.Library.WebApi.Tests/Equinor.Procosys.Library.WebApi.Tests.csproj
+++ b/src/Tests/Equinor.Procosys.Library.WebApi.Tests/Equinor.Procosys.Library.WebApi.Tests.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="Moq" Version="4.13.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.1.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.1.1" />
     <PackageReference Include="MSTest.TestFramework" Version="2.1.0" />
     <PackageReference Include="coverlet.collector" Version="1.2.1">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
12 packages were updated in 8 projects:
`MSTest.TestAdapter`, `MSTest.TestFramework`, `Microsoft.EntityFrameworkCore`, `Microsoft.EntityFrameworkCore.SqlServer`, `Microsoft.EntityFrameworkCore.Design`, `Microsoft.EntityFrameworkCore.Tools`, `Microsoft.Extensions.DependencyModel`, `Microsoft.Extensions.Http`, `Microsoft.AspNetCore.Authentication.JwtBearer`, `Microsoft.AspNetCore.Authentication.MicrosoftAccount`, `Microsoft.AspNetCore.Authentication.OpenIdConnect`, `Microsoft.EntityFrameworkCore.InMemory`
<details>
<summary>Details of updated packages</summary>

NuKeeper has generated a patch update of `MSTest.TestAdapter` to `2.1.1` from `2.1.0`
`MSTest.TestAdapter 2.1.1` was published at `2020-04-01T08:19:03Z`, 6 days ago

5 project updates:
Updated `Tests/Equinor.Procosys.Library.Infrastructure.Tests/Equinor.Procosys.Library.Infrastructure.Tests.csproj` to `MSTest.TestAdapter` `2.1.1` from `2.1.0`
Updated `Tests/Equinor.Procosys.Library.Domain.Tests/Equinor.Procosys.Library.Domain.Tests.csproj` to `MSTest.TestAdapter` `2.1.1` from `2.1.0`
Updated `Tests/Equinor.Procosys.Library.Command.Tests/Equinor.Procosys.Library.Command.Tests.csproj` to `MSTest.TestAdapter` `2.1.1` from `2.1.0`
Updated `Tests/Equinor.Procosys.Library.WebApi.Tests/Equinor.Procosys.Library.WebApi.Tests.csproj` to `MSTest.TestAdapter` `2.1.1` from `2.1.0`
Updated `Tests/Equinor.Procosys.Library.Query.Tests/Equinor.Procosys.Library.Query.Tests.csproj` to `MSTest.TestAdapter` `2.1.1` from `2.1.0`

[MSTest.TestAdapter 2.1.1 on NuGet.org](https://www.nuget.org/packages/MSTest.TestAdapter/2.1.1)

NuKeeper has generated a patch update of `MSTest.TestFramework` to `2.1.1` from `2.1.0`
`MSTest.TestFramework 2.1.1` was published at `2020-04-01T08:20:23Z`, 6 days ago

5 project updates:
Updated `Tests/Equinor.Procosys.Library.Infrastructure.Tests/Equinor.Procosys.Library.Infrastructure.Tests.csproj` to `MSTest.TestFramework` `2.1.1` from `2.1.0`
Updated `Tests/Equinor.Procosys.Library.Domain.Tests/Equinor.Procosys.Library.Domain.Tests.csproj` to `MSTest.TestFramework` `2.1.1` from `2.1.0`
Updated `Tests/Equinor.Procosys.Library.Command.Tests/Equinor.Procosys.Library.Command.Tests.csproj` to `MSTest.TestFramework` `2.1.1` from `2.1.0`
Updated `Tests/Equinor.Procosys.Library.WebApi.Tests/Equinor.Procosys.Library.WebApi.Tests.csproj` to `MSTest.TestFramework` `2.1.1` from `2.1.0`
Updated `Tests/Equinor.Procosys.Library.Query.Tests/Equinor.Procosys.Library.Query.Tests.csproj` to `MSTest.TestFramework` `2.1.1` from `2.1.0`

[MSTest.TestFramework 2.1.1 on NuGet.org](https://www.nuget.org/packages/MSTest.TestFramework/2.1.1)

NuKeeper has generated a patch update of `Microsoft.EntityFrameworkCore` to `3.1.3` from `3.1.2`
`Microsoft.EntityFrameworkCore 3.1.3` was published at `2020-03-24T17:14:25Z`, 13 days ago

1 project update:
Updated `Equinor.Procosys.Library.Infrastructure/Equinor.Procosys.Library.Infrastructure.csproj` to `Microsoft.EntityFrameworkCore` `3.1.3` from `3.1.2`

[Microsoft.EntityFrameworkCore 3.1.3 on NuGet.org](https://www.nuget.org/packages/Microsoft.EntityFrameworkCore/3.1.3)

NuKeeper has generated a patch update of `Microsoft.EntityFrameworkCore.SqlServer` to `3.1.3` from `3.1.2`
`Microsoft.EntityFrameworkCore.SqlServer 3.1.3` was published at `2020-03-24T17:14:45Z`, 13 days ago

1 project update:
Updated `Equinor.Procosys.Library.Infrastructure/Equinor.Procosys.Library.Infrastructure.csproj` to `Microsoft.EntityFrameworkCore.SqlServer` `3.1.3` from `3.1.2`

[Microsoft.EntityFrameworkCore.SqlServer 3.1.3 on NuGet.org](https://www.nuget.org/packages/Microsoft.EntityFrameworkCore.SqlServer/3.1.3)

NuKeeper has generated a patch update of `Microsoft.EntityFrameworkCore.Design` to `3.1.3` from `3.1.2`
`Microsoft.EntityFrameworkCore.Design 3.1.3` was published at `2020-03-24T17:14:31Z`, 13 days ago

1 project update:
Updated `Equinor.Procosys.Library.WebApi/Equinor.Procosys.Library.WebApi.csproj` to `Microsoft.EntityFrameworkCore.Design` `3.1.3` from `3.1.2`

[Microsoft.EntityFrameworkCore.Design 3.1.3 on NuGet.org](https://www.nuget.org/packages/Microsoft.EntityFrameworkCore.Design/3.1.3)

NuKeeper has generated a patch update of `Microsoft.EntityFrameworkCore.Tools` to `3.1.3` from `3.1.2`
`Microsoft.EntityFrameworkCore.Tools 3.1.3` was published at `2020-03-24T17:14:48Z`, 13 days ago

1 project update:
Updated `Equinor.Procosys.Library.Infrastructure/Equinor.Procosys.Library.Infrastructure.csproj` to `Microsoft.EntityFrameworkCore.Tools` `3.1.3` from `3.1.2`

[Microsoft.EntityFrameworkCore.Tools 3.1.3 on NuGet.org](https://www.nuget.org/packages/Microsoft.EntityFrameworkCore.Tools/3.1.3)

NuKeeper has generated a patch update of `Microsoft.Extensions.DependencyModel` to `3.1.3` from `3.1.2`
`Microsoft.Extensions.DependencyModel 3.1.3` was published at `2020-03-24T17:10:00Z`, 13 days ago

1 project update:
Updated `Equinor.Procosys.Library.Infrastructure/Equinor.Procosys.Library.Infrastructure.csproj` to `Microsoft.Extensions.DependencyModel` `3.1.3` from `3.1.2`

[Microsoft.Extensions.DependencyModel 3.1.3 on NuGet.org](https://www.nuget.org/packages/Microsoft.Extensions.DependencyModel/3.1.3)

NuKeeper has generated a patch update of `Microsoft.Extensions.Http` to `3.1.3` from `3.1.2`
`Microsoft.Extensions.Http 3.1.3` was published at `2020-03-24T17:15:35Z`, 13 days ago

1 project update:
Updated `Equinor.Procosys.Library.Query/Equinor.Procosys.Library.Query.csproj` to `Microsoft.Extensions.Http` `3.1.3` from `3.1.2`

[Microsoft.Extensions.Http 3.1.3 on NuGet.org](https://www.nuget.org/packages/Microsoft.Extensions.Http/3.1.3)

NuKeeper has generated a patch update of `Microsoft.AspNetCore.Authentication.JwtBearer` to `3.1.3` from `3.1.2`
`Microsoft.AspNetCore.Authentication.JwtBearer 3.1.3` was published at `2020-03-24T17:12:19Z`, 13 days ago

1 project update:
Updated `Equinor.Procosys.Library.WebApi/Equinor.Procosys.Library.WebApi.csproj` to `Microsoft.AspNetCore.Authentication.JwtBearer` `3.1.3` from `3.1.2`

[Microsoft.AspNetCore.Authentication.JwtBearer 3.1.3 on NuGet.org](https://www.nuget.org/packages/Microsoft.AspNetCore.Authentication.JwtBearer/3.1.3)

NuKeeper has generated a patch update of `Microsoft.AspNetCore.Authentication.MicrosoftAccount` to `3.1.3` from `3.1.2`
`Microsoft.AspNetCore.Authentication.MicrosoftAccount 3.1.3` was published at `2020-03-24T17:12:20Z`, 13 days ago

1 project update:
Updated `Equinor.Procosys.Library.WebApi/Equinor.Procosys.Library.WebApi.csproj` to `Microsoft.AspNetCore.Authentication.MicrosoftAccount` `3.1.3` from `3.1.2`

[Microsoft.AspNetCore.Authentication.MicrosoftAccount 3.1.3 on NuGet.org](https://www.nuget.org/packages/Microsoft.AspNetCore.Authentication.MicrosoftAccount/3.1.3)

NuKeeper has generated a patch update of `Microsoft.AspNetCore.Authentication.OpenIdConnect` to `3.1.3` from `3.1.2`
`Microsoft.AspNetCore.Authentication.OpenIdConnect 3.1.3` was published at `2020-03-24T17:12:23Z`, 13 days ago

1 project update:
Updated `Equinor.Procosys.Library.WebApi/Equinor.Procosys.Library.WebApi.csproj` to `Microsoft.AspNetCore.Authentication.OpenIdConnect` `3.1.3` from `3.1.2`

[Microsoft.AspNetCore.Authentication.OpenIdConnect 3.1.3 on NuGet.org](https://www.nuget.org/packages/Microsoft.AspNetCore.Authentication.OpenIdConnect/3.1.3)

NuKeeper has generated a patch update of `Microsoft.EntityFrameworkCore.InMemory` to `3.1.3` from `3.1.2`
`Microsoft.EntityFrameworkCore.InMemory 3.1.3` was published at `2020-03-24T17:14:33Z`, 13 days ago

1 project update:
Updated `Tests/Equinor.Procosys.Library.Query.Tests/Equinor.Procosys.Library.Query.Tests.csproj` to `Microsoft.EntityFrameworkCore.InMemory` `3.1.3` from `3.1.2`

[Microsoft.EntityFrameworkCore.InMemory 3.1.3 on NuGet.org](https://www.nuget.org/packages/Microsoft.EntityFrameworkCore.InMemory/3.1.3)

</details>


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
