### PR TITLE
Automatic update of Microsoft.VisualStudio.Azure.Containers.Tools.Targets to 1.10.8

### DIFF
--- a/src/Equinor.Procosys.Library.WebApi/Equinor.Procosys.Library.WebApi.csproj
+++ b/src/Equinor.Procosys.Library.WebApi/Equinor.Procosys.Library.WebApi.csproj
@@ -22,7 +22,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Configuration.AzureKeyVault" Version="3.1.3" />
     <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="5.2.7" />
-    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.9.10" />
+    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.10.8" />
     <PackageReference Include="ServiceResult" Version="1.0.1" />
     <PackageReference Include="ServiceResult.ApiExtensions" Version="1.0.1" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="5.3.1" />


### PR DESCRIPTION
NuKeeper has generated a minor update of `Microsoft.VisualStudio.Azure.Containers.Tools.Targets` to `1.10.8` from `1.9.10`
`Microsoft.VisualStudio.Azure.Containers.Tools.Targets 1.10.8` was published at `2020-01-28T18:49:29Z`, 3 months ago

1 project update:
Updated `Equinor.Procosys.Library.WebApi/Equinor.Procosys.Library.WebApi.csproj` to `Microsoft.VisualStudio.Azure.Containers.Tools.Targets` `1.10.8` from `1.9.10`

[Microsoft.VisualStudio.Azure.Containers.Tools.Targets 1.10.8 on NuGet.org](https://www.nuget.org/packages/Microsoft.VisualStudio.Azure.Containers.Tools.Targets/1.10.8)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
