### PR TITLE
Automatic update of 3 packages

### DIFF
--- a/src/Equinor.Procosys.Library.WebApi/Equinor.Procosys.Library.WebApi.csproj
+++ b/src/Equinor.Procosys.Library.WebApi/Equinor.Procosys.Library.WebApi.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="MediatR" Version="8.0.1" />
     <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="8.0.0" />
     <PackageReference Include="MicroElements.Swashbuckle.FluentValidation" Version="3.1.0" />
-    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.13.1" />
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.14.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.PerfCounterCollector" Version="2.14.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.1.3" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="3.1.3" />

--- a/src/Equinor.Procosys.Library.WebApi/Equinor.Procosys.Library.WebApi.csproj
+++ b/src/Equinor.Procosys.Library.WebApi/Equinor.Procosys.Library.WebApi.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="8.0.0" />
     <PackageReference Include="MicroElements.Swashbuckle.FluentValidation" Version="3.1.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.13.1" />
-    <PackageReference Include="Microsoft.ApplicationInsights.PerfCounterCollector" Version="2.13.1" />
+    <PackageReference Include="Microsoft.ApplicationInsights.PerfCounterCollector" Version="2.14.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.1.3" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="3.1.3" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="3.1.3" />

--- a/src/Tests/Equinor.Procosys.Library.Command.Tests/Equinor.Procosys.Library.Command.Tests.csproj
+++ b/src/Tests/Equinor.Procosys.Library.Command.Tests/Equinor.Procosys.Library.Command.Tests.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="FluentValidation.AspNetCore" Version="8.6.2" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.1.1" />
     <PackageReference Include="MSTest.TestFramework" Version="2.1.1" />

--- a/src/Tests/Equinor.Procosys.Library.Domain.Tests/Equinor.Procosys.Library.Domain.Tests.csproj
+++ b/src/Tests/Equinor.Procosys.Library.Domain.Tests/Equinor.Procosys.Library.Domain.Tests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.1.1" />
     <PackageReference Include="MSTest.TestFramework" Version="2.1.1" />

--- a/src/Tests/Equinor.Procosys.Library.Infrastructure.Tests/Equinor.Procosys.Library.Infrastructure.Tests.csproj
+++ b/src/Tests/Equinor.Procosys.Library.Infrastructure.Tests/Equinor.Procosys.Library.Infrastructure.Tests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
     <PackageReference Include="MockQueryable.Moq" Version="3.1.2" />
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.1.1" />

--- a/src/Tests/Equinor.Procosys.Library.Query.Tests/Equinor.Procosys.Library.Query.Tests.csproj
+++ b/src/Tests/Equinor.Procosys.Library.Query.Tests/Equinor.Procosys.Library.Query.Tests.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.1.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.1.1" />
     <PackageReference Include="MSTest.TestFramework" Version="2.1.1" />

--- a/src/Tests/Equinor.Procosys.Library.WebApi.Tests/Equinor.Procosys.Library.WebApi.Tests.csproj
+++ b/src/Tests/Equinor.Procosys.Library.WebApi.Tests/Equinor.Procosys.Library.WebApi.Tests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.1.1" />
     <PackageReference Include="MSTest.TestFramework" Version="2.1.1" />


### PR DESCRIPTION
3 packages were updated in 6 projects:
`Microsoft.NET.Test.Sdk`, `Microsoft.ApplicationInsights.PerfCounterCollector`, `Microsoft.ApplicationInsights.AspNetCore`
<details>
<summary>Details of updated packages</summary>

NuKeeper has generated a minor update of `Microsoft.NET.Test.Sdk` to `16.6.1` from `16.5.0`
`Microsoft.NET.Test.Sdk 16.6.1` was published at `2020-04-24T09:53:18Z`, 9 days ago

5 project updates:
Updated `Tests/Equinor.Procosys.Library.Command.Tests/Equinor.Procosys.Library.Command.Tests.csproj` to `Microsoft.NET.Test.Sdk` `16.6.1` from `16.5.0`
Updated `Tests/Equinor.Procosys.Library.Query.Tests/Equinor.Procosys.Library.Query.Tests.csproj` to `Microsoft.NET.Test.Sdk` `16.6.1` from `16.5.0`
Updated `Tests/Equinor.Procosys.Library.Infrastructure.Tests/Equinor.Procosys.Library.Infrastructure.Tests.csproj` to `Microsoft.NET.Test.Sdk` `16.6.1` from `16.5.0`
Updated `Tests/Equinor.Procosys.Library.Domain.Tests/Equinor.Procosys.Library.Domain.Tests.csproj` to `Microsoft.NET.Test.Sdk` `16.6.1` from `16.5.0`
Updated `Tests/Equinor.Procosys.Library.WebApi.Tests/Equinor.Procosys.Library.WebApi.Tests.csproj` to `Microsoft.NET.Test.Sdk` `16.6.1` from `16.5.0`

[Microsoft.NET.Test.Sdk 16.6.1 on NuGet.org](https://www.nuget.org/packages/Microsoft.NET.Test.Sdk/16.6.1)

NuKeeper has generated a minor update of `Microsoft.ApplicationInsights.PerfCounterCollector` to `2.14.0` from `2.13.1`
`Microsoft.ApplicationInsights.PerfCounterCollector 2.14.0` was published at `2020-04-24T17:57:50Z`, 9 days ago

1 project update:
Updated `Equinor.Procosys.Library.WebApi/Equinor.Procosys.Library.WebApi.csproj` to `Microsoft.ApplicationInsights.PerfCounterCollector` `2.14.0` from `2.13.1`

[Microsoft.ApplicationInsights.PerfCounterCollector 2.14.0 on NuGet.org](https://www.nuget.org/packages/Microsoft.ApplicationInsights.PerfCounterCollector/2.14.0)

NuKeeper has generated a minor update of `Microsoft.ApplicationInsights.AspNetCore` to `2.14.0` from `2.13.1`
`Microsoft.ApplicationInsights.AspNetCore 2.14.0` was published at `2020-04-24T17:57:32Z`, 9 days ago

1 project update:
Updated `Equinor.Procosys.Library.WebApi/Equinor.Procosys.Library.WebApi.csproj` to `Microsoft.ApplicationInsights.AspNetCore` `2.14.0` from `2.13.1`

[Microsoft.ApplicationInsights.AspNetCore 2.14.0 on NuGet.org](https://www.nuget.org/packages/Microsoft.ApplicationInsights.AspNetCore/2.14.0)

</details>


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
