### PR TITLE
Setting ProCoSys team as reviewers

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,5 @@ updates:
     directory: "/src"
     schedule:
       interval: "weekly"
+    reviewers:
+      - "equinor/procosys"


### PR DESCRIPTION
Setting the ProCoSys team as reviewers for Dependabot PRs to avoid dangling PRs.