### PR TITLE
Automatic update of MicroElements.Swashbuckle.FluentValidation to 4.0.0

### DIFF
--- a/src/Equinor.Procosys.Library.WebApi/Equinor.Procosys.Library.WebApi.csproj
+++ b/src/Equinor.Procosys.Library.WebApi/Equinor.Procosys.Library.WebApi.csproj
@@ -9,7 +9,7 @@
     <PackageReference Include="FluentValidation.AspNetCore" Version="9.1.2" />
     <PackageReference Include="MediatR" Version="8.1.0" />
     <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="8.1.0" />
-    <PackageReference Include="MicroElements.Swashbuckle.FluentValidation" Version="4.0.0-rc.2" />
+    <PackageReference Include="MicroElements.Swashbuckle.FluentValidation" Version="4.0.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.14.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.PerfCounterCollector" Version="2.14.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.1.7" />


### PR DESCRIPTION
NuKeeper has generated a out of beta update of `MicroElements.Swashbuckle.FluentValidation` to `4.0.0` from `4.0.0-rc.2`
`MicroElements.Swashbuckle.FluentValidation 4.0.0` was published at `2020-08-21T18:55:04Z`, 10 days ago

1 project update:
Updated `Equinor.Procosys.Library.WebApi/Equinor.Procosys.Library.WebApi.csproj` to `MicroElements.Swashbuckle.FluentValidation` `4.0.0` from `4.0.0-rc.2`

[MicroElements.Swashbuckle.FluentValidation 4.0.0 on NuGet.org](https://www.nuget.org/packages/MicroElements.Swashbuckle.FluentValidation/4.0.0)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
