### PR TITLE
Automatic update of 11 packages

### DIFF
--- a/src/Equinor.Procosys.Library.Infrastructure/Equinor.Procosys.Library.Infrastructure.csproj
+++ b/src/Equinor.Procosys.Library.Infrastructure/Equinor.Procosys.Library.Infrastructure.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.8" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.7" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.8" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="3.1.7">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Equinor.Procosys.Library.Infrastructure/Equinor.Procosys.Library.Infrastructure.csproj
+++ b/src/Equinor.Procosys.Library.Infrastructure/Equinor.Procosys.Library.Infrastructure.csproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.8" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.8" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="3.1.7">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="3.1.8">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Equinor.Procosys.Library.Infrastructure/Equinor.Procosys.Library.Infrastructure.csproj
+++ b/src/Equinor.Procosys.Library.Infrastructure/Equinor.Procosys.Library.Infrastructure.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.7" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.8" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.7" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="3.1.7">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Equinor.Procosys.Library.Query/Equinor.Procosys.Library.Query.csproj
+++ b/src/Equinor.Procosys.Library.Query/Equinor.Procosys.Library.Query.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="MediatR" Version="8.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.7" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.8" />
     <PackageReference Include="ServiceResult" Version="1.0.1" />
   </ItemGroup>
 

--- a/src/Equinor.Procosys.Library.WebApi/Equinor.Procosys.Library.WebApi.csproj
+++ b/src/Equinor.Procosys.Library.WebApi/Equinor.Procosys.Library.WebApi.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentValidation.AspNetCore" Version="9.1.2" />
+    <PackageReference Include="FluentValidation.AspNetCore" Version="9.2.0" />
     <PackageReference Include="MediatR" Version="8.1.0" />
     <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="8.1.0" />
     <PackageReference Include="MicroElements.Swashbuckle.FluentValidation" Version="4.0.0-rc.2" />

--- a/src/Equinor.Procosys.Library.WebApi/Equinor.Procosys.Library.WebApi.csproj
+++ b/src/Equinor.Procosys.Library.WebApi/Equinor.Procosys.Library.WebApi.csproj
@@ -20,7 +20,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Configuration.AzureKeyVault" Version="3.1.7" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.AzureKeyVault" Version="3.1.8" />
     <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="5.2.8" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.10.8" />
     <PackageReference Include="ServiceResult" Version="1.0.1" />

--- a/src/Equinor.Procosys.Library.WebApi/Equinor.Procosys.Library.WebApi.csproj
+++ b/src/Equinor.Procosys.Library.WebApi/Equinor.Procosys.Library.WebApi.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="MicroElements.Swashbuckle.FluentValidation" Version="4.0.0-rc.2" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.14.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.PerfCounterCollector" Version="2.14.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.1.7" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.1.8" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="3.1.7" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="3.1.7" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="2.2.0" />

--- a/src/Equinor.Procosys.Library.WebApi/Equinor.Procosys.Library.WebApi.csproj
+++ b/src/Equinor.Procosys.Library.WebApi/Equinor.Procosys.Library.WebApi.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="3.1.7" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="3.1.7" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="2.2.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="3.1.7">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="3.1.8">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Equinor.Procosys.Library.WebApi/Equinor.Procosys.Library.WebApi.csproj
+++ b/src/Equinor.Procosys.Library.WebApi/Equinor.Procosys.Library.WebApi.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="Microsoft.ApplicationInsights.PerfCounterCollector" Version="2.14.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.1.8" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="3.1.8" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="3.1.7" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="3.1.8" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="3.1.8">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Equinor.Procosys.Library.WebApi/Equinor.Procosys.Library.WebApi.csproj
+++ b/src/Equinor.Procosys.Library.WebApi/Equinor.Procosys.Library.WebApi.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.14.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.PerfCounterCollector" Version="2.14.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.1.8" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="3.1.7" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="3.1.8" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="3.1.7" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="3.1.8">

--- a/src/Tests/Equinor.Procosys.Library.Query.Tests/Equinor.Procosys.Library.Query.Tests.csproj
+++ b/src/Tests/Equinor.Procosys.Library.Query.Tests/Equinor.Procosys.Library.Query.Tests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.1.7" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.1.8" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.0" />
     <PackageReference Include="Moq" Version="4.14.5" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />


### PR DESCRIPTION
11 packages were updated in 4 projects:
`FluentValidation.AspNetCore`, `Microsoft.EntityFrameworkCore`, `Microsoft.EntityFrameworkCore.SqlServer`, `Microsoft.EntityFrameworkCore.Design`, `Microsoft.EntityFrameworkCore.Tools`, `Microsoft.Extensions.Http`, `Microsoft.AspNetCore.Authentication.JwtBearer`, `Microsoft.AspNetCore.Authentication.MicrosoftAccount`, `Microsoft.AspNetCore.Authentication.OpenIdConnect`, `Microsoft.Extensions.Configuration.AzureKeyVault`, `Microsoft.EntityFrameworkCore.InMemory`
<details>
<summary>Details of updated packages</summary>

NuKeeper has generated a minor update of `FluentValidation.AspNetCore` to `9.2.0` from `9.1.2`
`FluentValidation.AspNetCore 9.2.0` was published at `2020-08-26T09:13:59Z`, 26 days ago

1 project update:
Updated `Equinor.Procosys.Library.WebApi/Equinor.Procosys.Library.WebApi.csproj` to `FluentValidation.AspNetCore` `9.2.0` from `9.1.2`

[FluentValidation.AspNetCore 9.2.0 on NuGet.org](https://www.nuget.org/packages/FluentValidation.AspNetCore/9.2.0)

NuKeeper has generated a patch update of `Microsoft.EntityFrameworkCore` to `3.1.8` from `3.1.7`
`Microsoft.EntityFrameworkCore 3.1.8` was published at `2020-09-08T14:10:01Z`, 13 days ago

1 project update:
Updated `Equinor.Procosys.Library.Infrastructure/Equinor.Procosys.Library.Infrastructure.csproj` to `Microsoft.EntityFrameworkCore` `3.1.8` from `3.1.7`

[Microsoft.EntityFrameworkCore 3.1.8 on NuGet.org](https://www.nuget.org/packages/Microsoft.EntityFrameworkCore/3.1.8)

NuKeeper has generated a patch update of `Microsoft.EntityFrameworkCore.SqlServer` to `3.1.8` from `3.1.7`
`Microsoft.EntityFrameworkCore.SqlServer 3.1.8` was published at `2020-09-08T14:09:52Z`, 13 days ago

1 project update:
Updated `Equinor.Procosys.Library.Infrastructure/Equinor.Procosys.Library.Infrastructure.csproj` to `Microsoft.EntityFrameworkCore.SqlServer` `3.1.8` from `3.1.7`

[Microsoft.EntityFrameworkCore.SqlServer 3.1.8 on NuGet.org](https://www.nuget.org/packages/Microsoft.EntityFrameworkCore.SqlServer/3.1.8)

NuKeeper has generated a patch update of `Microsoft.EntityFrameworkCore.Design` to `3.1.8` from `3.1.7`
`Microsoft.EntityFrameworkCore.Design 3.1.8` was published at `2020-09-08T14:09:55Z`, 13 days ago

1 project update:
Updated `Equinor.Procosys.Library.WebApi/Equinor.Procosys.Library.WebApi.csproj` to `Microsoft.EntityFrameworkCore.Design` `3.1.8` from `3.1.7`

[Microsoft.EntityFrameworkCore.Design 3.1.8 on NuGet.org](https://www.nuget.org/packages/Microsoft.EntityFrameworkCore.Design/3.1.8)

NuKeeper has generated a patch update of `Microsoft.EntityFrameworkCore.Tools` to `3.1.8` from `3.1.7`
`Microsoft.EntityFrameworkCore.Tools 3.1.8` was published at `2020-09-08T14:10:07Z`, 13 days ago

1 project update:
Updated `Equinor.Procosys.Library.Infrastructure/Equinor.Procosys.Library.Infrastructure.csproj` to `Microsoft.EntityFrameworkCore.Tools` `3.1.8` from `3.1.7`

[Microsoft.EntityFrameworkCore.Tools 3.1.8 on NuGet.org](https://www.nuget.org/packages/Microsoft.EntityFrameworkCore.Tools/3.1.8)

NuKeeper has generated a patch update of `Microsoft.Extensions.Http` to `3.1.8` from `3.1.7`
`Microsoft.Extensions.Http 3.1.8` was published at `2020-09-08T14:10:37Z`, 13 days ago

1 project update:
Updated `Equinor.Procosys.Library.Query/Equinor.Procosys.Library.Query.csproj` to `Microsoft.Extensions.Http` `3.1.8` from `3.1.7`

[Microsoft.Extensions.Http 3.1.8 on NuGet.org](https://www.nuget.org/packages/Microsoft.Extensions.Http/3.1.8)

NuKeeper has generated a patch update of `Microsoft.AspNetCore.Authentication.JwtBearer` to `3.1.8` from `3.1.7`
`Microsoft.AspNetCore.Authentication.JwtBearer 3.1.8` was published at `2020-09-08T14:09:20Z`, 13 days ago

1 project update:
Updated `Equinor.Procosys.Library.WebApi/Equinor.Procosys.Library.WebApi.csproj` to `Microsoft.AspNetCore.Authentication.JwtBearer` `3.1.8` from `3.1.7`

[Microsoft.AspNetCore.Authentication.JwtBearer 3.1.8 on NuGet.org](https://www.nuget.org/packages/Microsoft.AspNetCore.Authentication.JwtBearer/3.1.8)

NuKeeper has generated a patch update of `Microsoft.AspNetCore.Authentication.MicrosoftAccount` to `3.1.8` from `3.1.7`
`Microsoft.AspNetCore.Authentication.MicrosoftAccount 3.1.8` was published at `2020-09-08T14:09:01Z`, 13 days ago

1 project update:
Updated `Equinor.Procosys.Library.WebApi/Equinor.Procosys.Library.WebApi.csproj` to `Microsoft.AspNetCore.Authentication.MicrosoftAccount` `3.1.8` from `3.1.7`

[Microsoft.AspNetCore.Authentication.MicrosoftAccount 3.1.8 on NuGet.org](https://www.nuget.org/packages/Microsoft.AspNetCore.Authentication.MicrosoftAccount/3.1.8)

NuKeeper has generated a patch update of `Microsoft.AspNetCore.Authentication.OpenIdConnect` to `3.1.8` from `3.1.7`
`Microsoft.AspNetCore.Authentication.OpenIdConnect 3.1.8` was published at `2020-09-08T14:09:26Z`, 13 days ago

1 project update:
Updated `Equinor.Procosys.Library.WebApi/Equinor.Procosys.Library.WebApi.csproj` to `Microsoft.AspNetCore.Authentication.OpenIdConnect` `3.1.8` from `3.1.7`

[Microsoft.AspNetCore.Authentication.OpenIdConnect 3.1.8 on NuGet.org](https://www.nuget.org/packages/Microsoft.AspNetCore.Authentication.OpenIdConnect/3.1.8)

NuKeeper has generated a patch update of `Microsoft.Extensions.Configuration.AzureKeyVault` to `3.1.8` from `3.1.7`
`Microsoft.Extensions.Configuration.AzureKeyVault 3.1.8` was published at `2020-09-08T14:10:59Z`, 13 days ago

1 project update:
Updated `Equinor.Procosys.Library.WebApi/Equinor.Procosys.Library.WebApi.csproj` to `Microsoft.Extensions.Configuration.AzureKeyVault` `3.1.8` from `3.1.7`

[Microsoft.Extensions.Configuration.AzureKeyVault 3.1.8 on NuGet.org](https://www.nuget.org/packages/Microsoft.Extensions.Configuration.AzureKeyVault/3.1.8)

NuKeeper has generated a patch update of `Microsoft.EntityFrameworkCore.InMemory` to `3.1.8` from `3.1.7`
`Microsoft.EntityFrameworkCore.InMemory 3.1.8` was published at `2020-09-08T14:09:46Z`, 13 days ago

1 project update:
Updated `Tests/Equinor.Procosys.Library.Query.Tests/Equinor.Procosys.Library.Query.Tests.csproj` to `Microsoft.EntityFrameworkCore.InMemory` `3.1.8` from `3.1.7`

[Microsoft.EntityFrameworkCore.InMemory 3.1.8 on NuGet.org](https://www.nuget.org/packages/Microsoft.EntityFrameworkCore.InMemory/3.1.8)

</details>


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
