### PR TITLE
Automatic update of 15 packages

### DIFF
--- a/src/Equinor.Procosys.Library.Command/Equinor.Procosys.Library.Command.csproj
+++ b/src/Equinor.Procosys.Library.Command/Equinor.Procosys.Library.Command.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentValidation" Version="9.1.2" />
+    <PackageReference Include="FluentValidation" Version="9.2.2" />
     <PackageReference Include="MediatR" Version="8.1.0" />
     <PackageReference Include="ServiceResult" Version="1.0.1" />
     <PackageReference Include="System.Text.Json" Version="4.7.2" />

--- a/src/Equinor.Procosys.Library.Infrastructure/Equinor.Procosys.Library.Infrastructure.csproj
+++ b/src/Equinor.Procosys.Library.Infrastructure/Equinor.Procosys.Library.Infrastructure.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.8" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.7" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.8" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="3.1.7">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Equinor.Procosys.Library.Infrastructure/Equinor.Procosys.Library.Infrastructure.csproj
+++ b/src/Equinor.Procosys.Library.Infrastructure/Equinor.Procosys.Library.Infrastructure.csproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.8" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.8" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="3.1.7">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="3.1.8">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Equinor.Procosys.Library.Infrastructure/Equinor.Procosys.Library.Infrastructure.csproj
+++ b/src/Equinor.Procosys.Library.Infrastructure/Equinor.Procosys.Library.Infrastructure.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.7" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.8" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.7" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="3.1.7">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Equinor.Procosys.Library.Query/Equinor.Procosys.Library.Query.csproj
+++ b/src/Equinor.Procosys.Library.Query/Equinor.Procosys.Library.Query.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="MediatR" Version="8.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.7" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.8" />
     <PackageReference Include="ServiceResult" Version="1.0.1" />
   </ItemGroup>
 

--- a/src/Equinor.Procosys.Library.WebApi/Equinor.Procosys.Library.WebApi.csproj
+++ b/src/Equinor.Procosys.Library.WebApi/Equinor.Procosys.Library.WebApi.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentValidation.AspNetCore" Version="9.1.2" />
+    <PackageReference Include="FluentValidation.AspNetCore" Version="9.2.0" />
     <PackageReference Include="MediatR" Version="8.1.0" />
     <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="8.1.0" />
     <PackageReference Include="MicroElements.Swashbuckle.FluentValidation" Version="4.0.0-rc.2" />

--- a/src/Equinor.Procosys.Library.WebApi/Equinor.Procosys.Library.WebApi.csproj
+++ b/src/Equinor.Procosys.Library.WebApi/Equinor.Procosys.Library.WebApi.csproj
@@ -20,7 +20,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Configuration.AzureKeyVault" Version="3.1.7" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.AzureKeyVault" Version="3.1.8" />
     <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="5.2.8" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.10.8" />
     <PackageReference Include="ServiceResult" Version="1.0.1" />

--- a/src/Equinor.Procosys.Library.WebApi/Equinor.Procosys.Library.WebApi.csproj
+++ b/src/Equinor.Procosys.Library.WebApi/Equinor.Procosys.Library.WebApi.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="MicroElements.Swashbuckle.FluentValidation" Version="4.0.0-rc.2" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.15.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.PerfCounterCollector" Version="2.15.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.1.7" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.1.8" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="3.1.7" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="3.1.7" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="2.2.0" />

--- a/src/Equinor.Procosys.Library.WebApi/Equinor.Procosys.Library.WebApi.csproj
+++ b/src/Equinor.Procosys.Library.WebApi/Equinor.Procosys.Library.WebApi.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="MediatR" Version="8.1.0" />
     <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="8.1.0" />
     <PackageReference Include="MicroElements.Swashbuckle.FluentValidation" Version="4.0.0-rc.2" />
-    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.14.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.15.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.PerfCounterCollector" Version="2.15.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.1.7" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="3.1.7" />

--- a/src/Equinor.Procosys.Library.WebApi/Equinor.Procosys.Library.WebApi.csproj
+++ b/src/Equinor.Procosys.Library.WebApi/Equinor.Procosys.Library.WebApi.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="3.1.7" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="3.1.7" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="2.2.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="3.1.7">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="3.1.8">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Equinor.Procosys.Library.WebApi/Equinor.Procosys.Library.WebApi.csproj
+++ b/src/Equinor.Procosys.Library.WebApi/Equinor.Procosys.Library.WebApi.csproj
@@ -25,7 +25,7 @@
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.10.8" />
     <PackageReference Include="ServiceResult" Version="1.0.1" />
     <PackageReference Include="ServiceResult.ApiExtensions" Version="1.0.1" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="5.5.1" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="5.6.3" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
 

--- a/src/Equinor.Procosys.Library.WebApi/Equinor.Procosys.Library.WebApi.csproj
+++ b/src/Equinor.Procosys.Library.WebApi/Equinor.Procosys.Library.WebApi.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.15.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.PerfCounterCollector" Version="2.15.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.1.8" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="3.1.7" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="3.1.8" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="3.1.7" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="3.1.8">

--- a/src/Equinor.Procosys.Library.WebApi/Equinor.Procosys.Library.WebApi.csproj
+++ b/src/Equinor.Procosys.Library.WebApi/Equinor.Procosys.Library.WebApi.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="8.1.0" />
     <PackageReference Include="MicroElements.Swashbuckle.FluentValidation" Version="4.0.0-rc.2" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.14.0" />
-    <PackageReference Include="Microsoft.ApplicationInsights.PerfCounterCollector" Version="2.14.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights.PerfCounterCollector" Version="2.15.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.1.7" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="3.1.7" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="3.1.7" />

--- a/src/Equinor.Procosys.Library.WebApi/Equinor.Procosys.Library.WebApi.csproj
+++ b/src/Equinor.Procosys.Library.WebApi/Equinor.Procosys.Library.WebApi.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="Microsoft.ApplicationInsights.PerfCounterCollector" Version="2.15.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.1.8" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="3.1.8" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="3.1.7" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="3.1.8" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="3.1.8">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Tests/Equinor.Procosys.Library.Command.Tests/Equinor.Procosys.Library.Command.Tests.csproj
+++ b/src/Tests/Equinor.Procosys.Library.Command.Tests/Equinor.Procosys.Library.Command.Tests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentValidation" Version="9.1.2" />
+    <PackageReference Include="FluentValidation" Version="9.2.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.0" />
     <PackageReference Include="Moq" Version="4.14.5" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />

--- a/src/Tests/Equinor.Procosys.Library.Query.Tests/Equinor.Procosys.Library.Query.Tests.csproj
+++ b/src/Tests/Equinor.Procosys.Library.Query.Tests/Equinor.Procosys.Library.Query.Tests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.1.7" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.1.8" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.0" />
     <PackageReference Include="Moq" Version="4.14.5" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />


### PR DESCRIPTION
15 packages were updated in 6 projects:
`FluentValidation`, `Swashbuckle.AspNetCore`, `FluentValidation.AspNetCore`, `Microsoft.ApplicationInsights.PerfCounterCollector`, `Microsoft.ApplicationInsights.AspNetCore`, `Microsoft.EntityFrameworkCore`, `Microsoft.EntityFrameworkCore.SqlServer`, `Microsoft.EntityFrameworkCore.Design`, `Microsoft.EntityFrameworkCore.Tools`, `Microsoft.Extensions.Http`, `Microsoft.AspNetCore.Authentication.JwtBearer`, `Microsoft.AspNetCore.Authentication.MicrosoftAccount`, `Microsoft.AspNetCore.Authentication.OpenIdConnect`, `Microsoft.Extensions.Configuration.AzureKeyVault`, `Microsoft.EntityFrameworkCore.InMemory`
<details>
<summary>Details of updated packages</summary>

NuKeeper has generated a minor update of `FluentValidation` to `9.2.2` from `9.1.2`
`FluentValidation 9.2.2` was published at `2020-09-20T13:06:53Z`, 11 days ago

2 project updates:
Updated `Equinor.Procosys.Library.Command/Equinor.Procosys.Library.Command.csproj` to `FluentValidation` `9.2.2` from `9.1.2`
Updated `Tests/Equinor.Procosys.Library.Command.Tests/Equinor.Procosys.Library.Command.Tests.csproj` to `FluentValidation` `9.2.2` from `9.1.2`

[FluentValidation 9.2.2 on NuGet.org](https://www.nuget.org/packages/FluentValidation/9.2.2)

NuKeeper has generated a minor update of `Swashbuckle.AspNetCore` to `5.6.3` from `5.5.1`
`Swashbuckle.AspNetCore 5.6.3` was published at `2020-09-23T12:48:45Z`, 8 days ago

1 project update:
Updated `Equinor.Procosys.Library.WebApi/Equinor.Procosys.Library.WebApi.csproj` to `Swashbuckle.AspNetCore` `5.6.3` from `5.5.1`

[Swashbuckle.AspNetCore 5.6.3 on NuGet.org](https://www.nuget.org/packages/Swashbuckle.AspNetCore/5.6.3)

NuKeeper has generated a minor update of `FluentValidation.AspNetCore` to `9.2.0` from `9.1.2`
`FluentValidation.AspNetCore 9.2.0` was published at `2020-08-26T09:13:59Z`, 2 months ago

1 project update:
Updated `Equinor.Procosys.Library.WebApi/Equinor.Procosys.Library.WebApi.csproj` to `FluentValidation.AspNetCore` `9.2.0` from `9.1.2`

[FluentValidation.AspNetCore 9.2.0 on NuGet.org](https://www.nuget.org/packages/FluentValidation.AspNetCore/9.2.0)

NuKeeper has generated a minor update of `Microsoft.ApplicationInsights.PerfCounterCollector` to `2.15.0` from `2.14.0`
`Microsoft.ApplicationInsights.PerfCounterCollector 2.15.0` was published at `2020-09-15T22:24:11Z`, 16 days ago

1 project update:
Updated `Equinor.Procosys.Library.WebApi/Equinor.Procosys.Library.WebApi.csproj` to `Microsoft.ApplicationInsights.PerfCounterCollector` `2.15.0` from `2.14.0`

[Microsoft.ApplicationInsights.PerfCounterCollector 2.15.0 on NuGet.org](https://www.nuget.org/packages/Microsoft.ApplicationInsights.PerfCounterCollector/2.15.0)

NuKeeper has generated a minor update of `Microsoft.ApplicationInsights.AspNetCore` to `2.15.0` from `2.14.0`
`Microsoft.ApplicationInsights.AspNetCore 2.15.0` was published at `2020-09-15T22:23:56Z`, 16 days ago

1 project update:
Updated `Equinor.Procosys.Library.WebApi/Equinor.Procosys.Library.WebApi.csproj` to `Microsoft.ApplicationInsights.AspNetCore` `2.15.0` from `2.14.0`

[Microsoft.ApplicationInsights.AspNetCore 2.15.0 on NuGet.org](https://www.nuget.org/packages/Microsoft.ApplicationInsights.AspNetCore/2.15.0)

NuKeeper has generated a patch update of `Microsoft.EntityFrameworkCore` to `3.1.8` from `3.1.7`
`Microsoft.EntityFrameworkCore 3.1.8` was published at `2020-09-08T14:10:01Z`, 23 days ago

1 project update:
Updated `Equinor.Procosys.Library.Infrastructure/Equinor.Procosys.Library.Infrastructure.csproj` to `Microsoft.EntityFrameworkCore` `3.1.8` from `3.1.7`

[Microsoft.EntityFrameworkCore 3.1.8 on NuGet.org](https://www.nuget.org/packages/Microsoft.EntityFrameworkCore/3.1.8)

NuKeeper has generated a patch update of `Microsoft.EntityFrameworkCore.SqlServer` to `3.1.8` from `3.1.7`
`Microsoft.EntityFrameworkCore.SqlServer 3.1.8` was published at `2020-09-08T14:09:52Z`, 23 days ago

1 project update:
Updated `Equinor.Procosys.Library.Infrastructure/Equinor.Procosys.Library.Infrastructure.csproj` to `Microsoft.EntityFrameworkCore.SqlServer` `3.1.8` from `3.1.7`

[Microsoft.EntityFrameworkCore.SqlServer 3.1.8 on NuGet.org](https://www.nuget.org/packages/Microsoft.EntityFrameworkCore.SqlServer/3.1.8)

NuKeeper has generated a patch update of `Microsoft.EntityFrameworkCore.Design` to `3.1.8` from `3.1.7`
`Microsoft.EntityFrameworkCore.Design 3.1.8` was published at `2020-09-08T14:09:55Z`, 23 days ago

1 project update:
Updated `Equinor.Procosys.Library.WebApi/Equinor.Procosys.Library.WebApi.csproj` to `Microsoft.EntityFrameworkCore.Design` `3.1.8` from `3.1.7`

[Microsoft.EntityFrameworkCore.Design 3.1.8 on NuGet.org](https://www.nuget.org/packages/Microsoft.EntityFrameworkCore.Design/3.1.8)

NuKeeper has generated a patch update of `Microsoft.EntityFrameworkCore.Tools` to `3.1.8` from `3.1.7`
`Microsoft.EntityFrameworkCore.Tools 3.1.8` was published at `2020-09-08T14:10:07Z`, 23 days ago

1 project update:
Updated `Equinor.Procosys.Library.Infrastructure/Equinor.Procosys.Library.Infrastructure.csproj` to `Microsoft.EntityFrameworkCore.Tools` `3.1.8` from `3.1.7`

[Microsoft.EntityFrameworkCore.Tools 3.1.8 on NuGet.org](https://www.nuget.org/packages/Microsoft.EntityFrameworkCore.Tools/3.1.8)

NuKeeper has generated a patch update of `Microsoft.Extensions.Http` to `3.1.8` from `3.1.7`
`Microsoft.Extensions.Http 3.1.8` was published at `2020-09-08T14:10:37Z`, 23 days ago

1 project update:
Updated `Equinor.Procosys.Library.Query/Equinor.Procosys.Library.Query.csproj` to `Microsoft.Extensions.Http` `3.1.8` from `3.1.7`

[Microsoft.Extensions.Http 3.1.8 on NuGet.org](https://www.nuget.org/packages/Microsoft.Extensions.Http/3.1.8)

NuKeeper has generated a patch update of `Microsoft.AspNetCore.Authentication.JwtBearer` to `3.1.8` from `3.1.7`
`Microsoft.AspNetCore.Authentication.JwtBearer 3.1.8` was published at `2020-09-08T14:09:20Z`, 23 days ago

1 project update:
Updated `Equinor.Procosys.Library.WebApi/Equinor.Procosys.Library.WebApi.csproj` to `Microsoft.AspNetCore.Authentication.JwtBearer` `3.1.8` from `3.1.7`

[Microsoft.AspNetCore.Authentication.JwtBearer 3.1.8 on NuGet.org](https://www.nuget.org/packages/Microsoft.AspNetCore.Authentication.JwtBearer/3.1.8)

NuKeeper has generated a patch update of `Microsoft.AspNetCore.Authentication.MicrosoftAccount` to `3.1.8` from `3.1.7`
`Microsoft.AspNetCore.Authentication.MicrosoftAccount 3.1.8` was published at `2020-09-08T14:09:01Z`, 23 days ago

1 project update:
Updated `Equinor.Procosys.Library.WebApi/Equinor.Procosys.Library.WebApi.csproj` to `Microsoft.AspNetCore.Authentication.MicrosoftAccount` `3.1.8` from `3.1.7`

[Microsoft.AspNetCore.Authentication.MicrosoftAccount 3.1.8 on NuGet.org](https://www.nuget.org/packages/Microsoft.AspNetCore.Authentication.MicrosoftAccount/3.1.8)

NuKeeper has generated a patch update of `Microsoft.AspNetCore.Authentication.OpenIdConnect` to `3.1.8` from `3.1.7`
`Microsoft.AspNetCore.Authentication.OpenIdConnect 3.1.8` was published at `2020-09-08T14:09:26Z`, 23 days ago

1 project update:
Updated `Equinor.Procosys.Library.WebApi/Equinor.Procosys.Library.WebApi.csproj` to `Microsoft.AspNetCore.Authentication.OpenIdConnect` `3.1.8` from `3.1.7`

[Microsoft.AspNetCore.Authentication.OpenIdConnect 3.1.8 on NuGet.org](https://www.nuget.org/packages/Microsoft.AspNetCore.Authentication.OpenIdConnect/3.1.8)

NuKeeper has generated a patch update of `Microsoft.Extensions.Configuration.AzureKeyVault` to `3.1.8` from `3.1.7`
`Microsoft.Extensions.Configuration.AzureKeyVault 3.1.8` was published at `2020-09-08T14:10:59Z`, 23 days ago

1 project update:
Updated `Equinor.Procosys.Library.WebApi/Equinor.Procosys.Library.WebApi.csproj` to `Microsoft.Extensions.Configuration.AzureKeyVault` `3.1.8` from `3.1.7`

[Microsoft.Extensions.Configuration.AzureKeyVault 3.1.8 on NuGet.org](https://www.nuget.org/packages/Microsoft.Extensions.Configuration.AzureKeyVault/3.1.8)

NuKeeper has generated a patch update of `Microsoft.EntityFrameworkCore.InMemory` to `3.1.8` from `3.1.7`
`Microsoft.EntityFrameworkCore.InMemory 3.1.8` was published at `2020-09-08T14:09:46Z`, 23 days ago

1 project update:
Updated `Tests/Equinor.Procosys.Library.Query.Tests/Equinor.Procosys.Library.Query.Tests.csproj` to `Microsoft.EntityFrameworkCore.InMemory` `3.1.8` from `3.1.7`

[Microsoft.EntityFrameworkCore.InMemory 3.1.8 on NuGet.org](https://www.nuget.org/packages/Microsoft.EntityFrameworkCore.InMemory/3.1.8)

</details>


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
