### PR TITLE
Automatic update of MediatR to 9.0.0

### DIFF
--- a/src/Equinor.Procosys.Library.Domain/Equinor.Procosys.Library.Domain.csproj
+++ b/src/Equinor.Procosys.Library.Domain/Equinor.Procosys.Library.Domain.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MediatR" Version="8.1.0" />
+    <PackageReference Include="MediatR" Version="9.0.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
NuKeeper has generated a major update of `MediatR` to `9.0.0` from `8.1.0`
`MediatR 9.0.0` was published at `2020-10-08T15:29:10Z`, 4 months ago

1 project update:
Updated `Equinor.Procosys.Library.Domain/Equinor.Procosys.Library.Domain.csproj` to `MediatR` `9.0.0` from `8.1.0`

[MediatR 9.0.0 on NuGet.org](https://www.nuget.org/packages/MediatR/9.0.0)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
